### PR TITLE
(bug): Fix the api url generated by server

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -15,7 +15,7 @@ var routes = Routes{
 	Route{
 		"fileapi",
 		"GET",
-		"/api",
+		"/chaos",
 		fileHandler,
 	},
 	Route{

--- a/src/components/ChartDetails.js
+++ b/src/components/ChartDetails.js
@@ -86,7 +86,7 @@ export class ChartDetails extends React.Component {
     this.host = window.location.host
     var path = this.props.charts.spec.chaosExpCRDLink
     path = path.split("/charts/")[1]
-    var displayRepoPath = "https://"+this.host+"/api?file=charts/" + path
+    var displayRepoPath = "https://"+this.host+"/api/chaos?file=charts/" + path
     return displayRepoPath
   }
 


### PR DESCRIPTION
Signed-off-by: chandan kumar <chandan.kumar@mayadata.io>

This commit will fix the following changes:
-  Fix the URL generated by the client for download the chaos-chart
-  Fix the API request handled by the chaos-chart server

Issue Reference: https://github.com/litmuschaos/litmus/issues/853

After:
![Screenshot from 2019-10-18 02-24-26](https://user-images.githubusercontent.com/28861964/67046717-71c52780-f14e-11e9-989a-e913dff38b35.png)

![Screenshot from 2019-10-18 02-25-15](https://user-images.githubusercontent.com/28861964/67046780-8ef9f600-f14e-11e9-917f-76d81caacc0b.png)
