### PR TITLE
(typo-fix) <area/charthub> : litmus icon link for charts

### DIFF
--- a/server/charts/generic/generic.chartserviceversion.yaml
+++ b/server/charts/generic/generic.chartserviceversion.yaml
@@ -37,6 +37,6 @@ spec:
     - name: Documentation
       url: https://kubernetes.io/docs/home/
   icon:
-    - url: https://raw.githubusercontent.com/litmuschaos/charthub.litmuschaos.io/master/public/icons/litmus.png
+    - url: https://raw.githubusercontent.com/litmuschaos/charthub.litmuschaos.io/master/public/charts-logos/litmus.png
       mediatype: image/png
   chaosexpcrdlink: https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/experiments.yaml


### PR DESCRIPTION
changed icon's link in generic.chartversion.yaml

Signed-off-by: daitya109 <adikid1996@gmail.com>
Reference issue : https://github.com/litmuschaos/litmus/issues/853