### PR TITLE
Added platforms inside chaos experiment charts

### DIFF
--- a/server/controller/handler/chart.go
+++ b/server/controller/handler/chart.go
@@ -65,6 +65,7 @@ type Spec struct {
 
 	Experiments     []string `yaml:"experiments"`
 	ChaosExpCRDLink string   `yaml:"chaosexpcrdlink"`
+	Platforms       []string `yaml:"platforms"`
 }
 
 type PackageInformation struct {

--- a/src/components/ChartDetails.js
+++ b/src/components/ChartDetails.js
@@ -61,8 +61,6 @@ export class ChartDetails extends React.Component {
   }
   getPlatformList = (listofPlatforms) => {
     let div = [];
-
-    console.log('hello..................................', listofPlatforms);
     if (listofPlatforms != null && listofPlatforms.length > 0) {
       div.push(<span className="uses-explanation-title"> Platforms</span>)
       for (let i = 0; i < listofPlatforms.length; i++) {

--- a/src/components/ChartDetails.js
+++ b/src/components/ChartDetails.js
@@ -59,6 +59,18 @@ export class ChartDetails extends React.Component {
     }
     return div;
   }
+  getPlatformList = (listofPlatforms) => {
+    let div = [];
+
+    console.log('hello..................................', listofPlatforms);
+    if (listofPlatforms != null && listofPlatforms.length > 0) {
+      div.push(<span className="uses-explanation-title"> Platforms</span>)
+      for (let i = 0; i < listofPlatforms.length; i++) {
+        div.push(<span key={i}>{listofPlatforms[i]}</span>)
+      }
+    }
+    return div
+  }
 
   handleOpenModal() {
     this.setState({ showModal: true });
@@ -167,6 +179,15 @@ export class ChartDetails extends React.Component {
               {this.getMaintainerList(this.props.charts.spec.maintainers)}
             </div>
           </div>
+
+          {this.props.charts.spec.platforms != null &&
+            <div className="d-flex item-block">
+              <i className="mi-user dark-gray"></i>
+              <div className="d-flex flex-column items">
+                {this.getPlatformList(this.props.charts.spec.platforms)}
+              </div>
+            </div>
+            }
 
         </div>
       </div>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -53,6 +53,7 @@ class Home extends React.Component {
                 experimentCount={chart.experiments ? chart.experiments.length : 0}
                 title={chart.spec.displayName}
                 provider={chart.spec.provider.name}
+                Platforms={chart.spec.platforms}
                 text={chart.metadata.annotations.chartDescription}
                 icon={logo + chart.metadata.name +".png"} 
                 id={chart.metadata.name}/>


### PR DESCRIPTION
-  This PR includes platform details in which the experiments can be executed.
-  Platform details are given inside chaos charts 


**Updated Platforms :**

![platform](https://user-images.githubusercontent.com/33670159/70625247-07a99a00-1c48-11ea-8084-446f540f7747.png)
