### PR TITLE
Added maturity inside chaos experiment charts

### DIFF
--- a/src/components/ChartDetails.js
+++ b/src/components/ChartDetails.js
@@ -60,6 +60,15 @@ export class ChartDetails extends React.Component {
     return div;
   }
 
+  getMaturityOfExperiment = (maturityOfExperiment) => {
+    let div = [];
+    if (maturityOfExperiment != "") {
+      div.push(<span className="uses-explanation-title"> Maturity</span>)
+        div.push(<span >{maturityOfExperiment}</span>)
+    }
+    return div
+  }
+
   handleOpenModal() {
     this.setState({ showModal: true });
   }
@@ -167,7 +176,14 @@ export class ChartDetails extends React.Component {
               {this.getMaintainerList(this.props.charts.spec.maintainers)}
             </div>
           </div>
-
+          {this.props.charts.spec.maturity != null &&
+            <div className="d-flex item-block">
+              <i className="mi-user dark-gray"></i>
+              <div className="d-flex flex-column items">
+                {this.getMaturityOfExperiment(this.props.charts.spec.maturity)}
+              </div>
+            </div>
+            }
         </div>
       </div>
       <Modal

--- a/src/components/ChartDetails.js
+++ b/src/components/ChartDetails.js
@@ -176,7 +176,7 @@ export class ChartDetails extends React.Component {
               {this.getMaintainerList(this.props.charts.spec.maintainers)}
             </div>
           </div>
-          {this.props.charts.spec.maturity != null &&
+          {this.props.charts.spec.maturity != '' &&
             <div className="d-flex item-block">
               <i className="mi-user dark-gray"></i>
               <div className="d-flex flex-column items">

--- a/src/components/ChartDetails.js
+++ b/src/components/ChartDetails.js
@@ -62,7 +62,7 @@ export class ChartDetails extends React.Component {
 
   getMaturityOfExperiment = (maturityOfExperiment) => {
     let div = [];
-    if (maturityOfExperiment != "") {
+    if (maturityOfExperiment != '') {
       div.push(<span className="uses-explanation-title"> Maturity</span>)
         div.push(<span >{maturityOfExperiment}</span>)
     }
@@ -178,7 +178,6 @@ export class ChartDetails extends React.Component {
           </div>
           {this.props.charts.spec.maturity != '' &&
             <div className="d-flex item-block">
-              <i className="mi-user dark-gray"></i>
               <div className="d-flex flex-column items">
                 {this.getMaturityOfExperiment(this.props.charts.spec.maturity)}
               </div>


### PR DESCRIPTION
- This PR includes maturity  details of chaos-experiments

- Maturity details of experiments are given inside chaos-experiments

**Updated Maturity**
![maturity](https://user-images.githubusercontent.com/33670159/70703488-4302a200-1cf6-11ea-9906-0ec851f420e3.png)
