### PR TITLE
(icon): Update the chaos chart icon path

### DIFF
--- a/server/controller/handler/handlers.go
+++ b/server/controller/handler/handlers.go
@@ -33,7 +33,7 @@ import (
 )
 
 // ChaosChartPath refers the location of the freshly updated repository
-var ChaosChartPath = os.Getenv("GOPATH") + "/src/github.com/litmuschaos/chaos-charts/"
+var ChaosChartPath = os.Getenv("GOPATH") + "/src/github.com/litmuschaos/charthub.litmuschaos.io/public/chaos-charts/"
 
 /*	pathParser reads the path in the csv file <path> forms the system-path <fileLookedPath>
 	and returns the file

--- a/server/pkg/gitops/gitwork.go
+++ b/server/pkg/gitops/gitwork.go
@@ -176,7 +176,7 @@ func (object GitConfig) GitPull() error {
 		return err
 	}
 	log.Info("git pull origin")
-	if w.Pull(&git.PullOptions{RemoteName: object.RemoteName}) != nil { // Pull the latest changes from the origin remote and merge into the current branch
+	if w.Pull(&git.PullOptions{RemoteName: object.RemoteName, ReferenceName: plumbing.NewBranchReferenceName(object.TargetBranch)}) != nil { // Pull the latest changes from the origin remote and merge into the current branch
 		return fmt.Errorf("error in executing Pull: %s", w.Pull(&git.PullOptions{RemoteName: object.RemoteName}))
 	}
 	log.Info("git rev-parse HEA--D") // Retrieve the branch pointed by HEAD

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -100,10 +100,7 @@ class Home extends React.Component {
   renderChartGrid = () => {
     try {
       return this.props.charts.map(chart => {
-        let logo =
-          'https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/' +
-          chart.metadata.name +
-          '/icons/';
+        let logo = './chaos-charts/charts/' + chart.metadata.name + '/icons/';
         return (
           <ChartCard
             isCard={this.state.isGridView}

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -7,8 +7,8 @@
 
   .home-content {
     box-sizing: border-box;
-    padding-left: 153px;
-    padding-right: 153px;
+    padding-left: 115px;
+    padding-right: 66px;
     padding-top: 60px;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
- Update the path of chaos-chart
  - Now it will pick the icon from cloned chaos-chart instead of GitHub
- Pass the target branch name while executing git pull

Signed-off-by: Chandan Kumar <chandan.kumar@mayadata.io>