### PR TITLE
(fix): Fix the edge case when file is not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
-/.idea
+.idea
 
 # testing
 /coverage

--- a/server/controller/handler/handlers.go
+++ b/server/controller/handler/handlers.go
@@ -142,7 +142,7 @@ func getYAMLFileContent(fileLocation string) (Chart, error) {
 		experimentFilePath := fileLocation + "/" + exp.Name + "/" + exp.Name + ".chartserviceversion.yaml"
 		experiment, err := readExperimentFile(experimentFilePath)
 		if err != nil {
-			return chart, fmt.Errorf("file path of the error: %+v", err)
+			log.Error(err)
 		}
 		chart.Experiments = append(chart.Experiments, experiment)
 	}

--- a/server/pkg/gitops/gitwork.go
+++ b/server/pkg/gitops/gitwork.go
@@ -86,7 +86,7 @@ func (c GitConfig) getChaosChartVersion() ([]string, error) {
 	var versions []string
 	versions = append(versions, defaultBranch)
 	err = tagrefs.ForEach(func(t *plumbing.Reference) error {
-		versions = append(versions, t.Name().Short())
+		versions = append([]string{t.Name().Short()}, versions...)
 		return nil
 	})
 	if err != nil {

--- a/src/components/HomeHeader.js
+++ b/src/components/HomeHeader.js
@@ -19,7 +19,7 @@ class HomeHeader extends React.Component {
 
   componentDidMount() {
     this.props.loadVersion()
-    // TODO: Remove the usases of setInterval
+    // TODO: Remove the usages of setInterval
     this.timer = setInterval(
       () =>  {
         this.props.loadCharts(getVersion(this.props.versions));
@@ -148,7 +148,7 @@ class HomeHeader extends React.Component {
                   Docs<span className='contribute-icon-container'></span>
                 </h3>
               </a>
-              <Dropdown options={this.props.versions.reverse()} onChange={this.changeVersion} value={getVersion(this.props.versions)}/>
+              <Dropdown options={this.props.versions} onChange={this.changeVersion} value={getVersion(this.props.versions)}/>
             </div>
             {this.renderHomeText()}
             {this.renderChartTitle()}


### PR DESCRIPTION
This commit will have this fix:
- Fix the get chart data issue, Instead of returning the empty data it will return the file data which ever is available
- Fix the reversing of versioning data from backend instead of doing it in frontend