### PR TITLE
Removed round off in analytics count

### DIFF
--- a/src/common/addMetrics.js
+++ b/src/common/addMetrics.js
@@ -1,11 +1,13 @@
 export const standardizeMetrics = num => {
   if (num > 1000000) {
     let suffix = 'M+';
-    let numeric_prefix = ((num * 1.0) / 1000000).toFixed(1);
+    let numeric_prefix = ((num * 1.0) / 1000000);
+    numeric_prefix = Math.floor(numeric_prefix*10)/10;
     return numeric_prefix + suffix;
   } else if (num > 1000) {
     let suffix = 'K+';
-    let numeric_prefix = ((num * 1.0) / 1000).toFixed(1);
+    let numeric_prefix = ((num * 1.0) / 1000);
+    numeric_prefix = Math.floor(numeric_prefix*10)/10;
     return numeric_prefix + suffix;
   } else {
     return num + '';


### PR DESCRIPTION
Following  changes made with this PR -:
 showing Actual Analytics count with 1 digit to the right decimal place.
Eg - 
   Total `CHAOS OPERATORS INSTALLED`   6879 
   Showing in K+, M+ format, It will be converted into 6.8K instead of 6.9K (6.979).

Please refer Attached Screen shot - 
**Before -** 
  
![Screenshot from 2020-05-07 18-46-25](https://user-images.githubusercontent.com/28762224/81301545-d1f1cb80-9096-11ea-8d91-d6f4df4e169d.png)

**After changes** 

![Screenshot from 2020-05-07 18-47-47](https://user-images.githubusercontent.com/28762224/81301598-e0d87e00-9096-11ea-8bd6-a4dd7d5e7f45.png)




Signed-off-by: ashishjain <ashish.jain@mayadata.io>