### PR TITLE
(Webhook): Add the support to sync the chaos-chart a/c to the webhook event

### DIFF
--- a/server/controller/handler/handlers.go
+++ b/server/controller/handler/handlers.go
@@ -30,6 +30,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/litmuschaos/charthub.litmuschaos.io/server/pkg/analytics"
+	"github.com/litmuschaos/charthub.litmuschaos.io/server/pkg/gitops"
 )
 
 // ChaosChartPath refers the location of the freshly updated repository
@@ -184,6 +185,13 @@ func GetChartVersion(w http.ResponseWriter, r *http.Request) {
 	writeHeaders(&w, 200)
 	(w).Header().Set("Access-Control-Allow-Origin", "*")
 	fmt.Fprint(w, string(version))
+}
+
+// Sync the chaos-chart a/c to the webhook event
+func Webhook(w http.ResponseWriter, r *http.Request) {
+	// Trigger the chaos-chart sync method in go routine without blocking the webhook response
+	go gitops.Trigger()
+	writeHeaders(&w, 200)
 }
 
 func writeHeaders(w *http.ResponseWriter, statusCode int) {

--- a/server/main.go
+++ b/server/main.go
@@ -5,15 +5,12 @@ import (
 	"net/http"
 
 	"github.com/litmuschaos/charthub.litmuschaos.io/server/pkg/analytics"
-	"github.com/litmuschaos/charthub.litmuschaos.io/server/pkg/gitops"
 	"github.com/litmuschaos/charthub.litmuschaos.io/server/routes"
 )
 
 func main() {
 	// Handler is go-routine which synchronously calls the git-ops function UpdateAnalyticsData()
 	go analytics.Handler()
-	// Trigger is go-routine which synchronously calls the git-ops function Trigger()
-	go gitops.Trigger()
 	router := routes.NewRouter()
 	log.Fatal(http.ListenAndServe(":8080", router))
 }

--- a/server/pkg/gitops/gitwork.go
+++ b/server/pkg/gitops/gitwork.go
@@ -22,17 +22,13 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
-
-	"github.com/litmuschaos/charthub.litmuschaos.io/server/controller/handler"
 )
 
 const (
-	timeInterval  = 1 * time.Hour
 	defaultBranch = "master"
 )
 
@@ -55,20 +51,18 @@ var (
 
 // Trigger is reposible for setting off the go routine for git-op
 func Trigger() {
+	// TODO: Define a single place where the repository name is defined
 	gitConfig := GitConfig{
-		RepositoryName: handler.ChaosChartPath,
+		RepositoryName: os.Getenv("GOPATH") + "/src/github.com/litmuschaos/charthub.litmuschaos.io/public/chaos-charts/",
 		RepositoryURL:  "https://github.com/litmuschaos/chaos-charts",
 		LocalCommit:    "", RemoteCommit: "", RemoteName: "origin",
 	}
-	for {
-		versions, _ := gitConfig.getChaosChartVersion()
-		for _, version := range versions {
-			if err := gitConfig.chaosChartSyncHandler(version); err != nil {
-				log.Error(err)
-			}
-			log.Infof("********* Repository syncing completed for version: '%s' *********", version)
+	versions, _ := gitConfig.getChaosChartVersion()
+	for _, version := range versions {
+		if err := gitConfig.chaosChartSyncHandler(version); err != nil {
+			log.Error(err)
 		}
-		time.Sleep(timeInterval)
+		log.Infof("********* Repository syncing completed for version: '%s' *********", version)
 	}
 }
 

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -62,4 +62,10 @@ var routes = Routes{
 		"/version",
 		handler.GetChartVersion,
 	},
+	Route{
+		"Webhook",
+		"POST",
+		"/webhook",
+		handler.Webhook,
+	},
 }


### PR DESCRIPTION
Why we need this?

- This commit will remove the syncing of chao-chart in defined period and it will sync on the chaos-chart based on the webhook

Issue: https://github.com/litmuschaos/litmus/issues/1461

Signed-off-by: Chandan Kumar <chandan.kumar@mayadata.io>