### PR TITLE
Updated Backend Image

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -5,15 +5,18 @@ WORKDIR $GOPATH/src/github.com/litmuschaos/charthub.litmuschaos.io/app/server
 ADD app/server $GOPATH/src/github.com/litmuschaos/charthub.litmuschaos.io/app/server
 
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh     
-		
+
 RUN dep ensure -v
 
-RUN go build -o ./build/_output/bin/charthub-server -v
+RUN CGO_ENABLED=0 go build -o /charthub-server -v
 
 
-FROM golang:1.14
+FROM alpine:latest
 
-COPY --from=builder $GOPATH/src/github.com/litmuschaos/charthub.litmuschaos.io/app/server/build/_output/bin/charthub-server /
+RUN apk update && apk add curl bash
+RUN apk add --no-cache libc6-compat
+
+COPY --from=builder /charthub-server /
 
 CMD ["/charthub-server"]
 


### PR DESCRIPTION
- Reduced backend docker image size from 831MB to 32MB
- Fixes issue #192 
Signed-off-by: gdsoumya <gdsoumya@gmail.com>