### PR TITLE
fix:- slack redirection to kubernetes slack url

### DIFF
--- a/app/client/src/components/Footer/index.tsx
+++ b/app/client/src/components/Footer/index.tsx
@@ -109,7 +109,7 @@ function AboutUs() {
 const community: CommunityItem[] = [
 	{
 		value: "Slack",
-		link: "https://app.slack.com/client/T09NY5SBT/CNXNB0ZTN",
+		link: "https://slack.litmuschaos.io",
 	},
 	{ value: "GitHub", link: "https://github.com/litmuschaos" },
 	{ value: "Twitter", link: "https://twitter.com/LitmusChaos" },


### PR DESCRIPTION
Changes made with this PR - 
Fixed Slack redirection `slack.litmuschaos`  to kubernete `kubernetes.slack.com`



Signed-off-by: ashishjain <ashish.jain@mayadata.io>