### PR TITLE
Fix broken link for Get Started

### DIFF
--- a/app/client/src/components/Header/index.tsx
+++ b/app/client/src/components/Header/index.tsx
@@ -43,7 +43,7 @@ export default function MainHeader() {
 	};
 
 	const handleGetStarted = () => {
-		window.open("https://docs.litmuschaos.io/docs/getstarted/");
+		window.open("https://docs.litmuschaos.io/docs/getting-started/installation");
 	};
 
 	const handleStars = () => {


### PR DESCRIPTION
I'm not sure it is a proper fix for https://hub.litmuschaos.io/ , because I'm not familiar with Litmus.

In website, "Get Started" button linked 404 Not Found.

<img width="1569" alt="스크린샷 2021-08-22 오후 5 36 37" src="https://user-images.githubusercontent.com/390146/130348082-ea3cc804-f147-4fc2-8956-6cb9bfd2548b.png">

<img width="524" alt="스크린샷 2021-08-22 오후 5 38 22" src="https://user-images.githubusercontent.com/390146/130348167-bf008613-2cad-42bb-a360-d361e978f085.png">

I guess <https://docs.litmuschaos.io/docs/getting-started/installation> is a correct URL now.