### PR TITLE
Fix nil pointer panics in ChartHub git sync and icon handler

### DIFF
--- a/app/server/controller/handler/handlers.go
+++ b/app/server/controller/handler/handlers.go
@@ -56,16 +56,17 @@ func pathParser(path string) ([]byte, error) {
 func GetIconHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	img, err := os.Open(ChaosChartPath + vars["version"] + "/faults/" + vars["expGroup"] + "/icons/" + vars["iconFile"])
-	responseStatusCode := 200
 	if err != nil {
-		responseStatusCode = 500
 		log.Error(err)
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, "icon cannot be fetched, err : "+err.Error())
+		return
 	}
 	defer img.Close()
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.WriteHeader(responseStatusCode)
-	w.Header().Set("Content-Type", "image/png") // <-- set the content-type header
+	w.Header().Set("Content-Type", "image/png")
+	w.WriteHeader(http.StatusOK)
 	io.Copy(w, img)
 }
 

--- a/app/server/pkg/gitops/gitwork.go
+++ b/app/server/pkg/gitops/gitwork.go
@@ -76,11 +76,24 @@ func Trigger() {
 }
 
 func (c GitConfig) getChaosChartVersion() ([]string, error) {
-	os.RemoveAll("/tmp/version")
-	r, _ := git.PlainClone("/tmp/version", false, &git.CloneOptions{
-		URL: c.RepositoryURL, Progress: os.Stdout,
+	// Clone to temporary path first to preserve existing data on failure
+	tmpClonePath := "/tmp/version-tmp"
+	os.RemoveAll(tmpClonePath)
+
+	r, err := git.PlainClone(tmpClonePath, false, &git.CloneOptions{
+		URL:           c.RepositoryURL,
+		Progress:      os.Stdout,
 		ReferenceName: plumbing.NewBranchReferenceName(defaultBranch),
 	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to clone chaos-charts repository: %w", err)
+	}
+
+	// Clone succeeded - now safe to replace old version data
+	os.RemoveAll("/tmp/version")
+	if err := os.Rename(tmpClonePath, "/tmp/version"); err != nil {
+		return nil, fmt.Errorf("unable to move cloned repository: %w", err)
+	}
 
 	tagrefs, err := r.Tags()
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR fixes **two production-crashing nil pointer panics** in the ChartHub backend caused by **ignored errors and unsafe assumptions**.

Both issues can be triggered by **real-world failures** (network outages, missing files) and currently cause the **entire service to crash** instead of failing gracefully.

---

## Issues Fixed

### 1. Git Sync Handler Panic on Clone Failure

**File:** `app/server/pkg/gitops/gitwork.go`  
**Function:** `getChaosChartVersion()`

#### Problem
The git clone error was ignored:

```go
r, _ := git.PlainClone(...)
tagrefs, err := r.Tags() // r is nil on clone failure → panic
